### PR TITLE
Add accounting input step

### DIFF
--- a/src/components/TaxForm.tsx
+++ b/src/components/TaxForm.tsx
@@ -9,6 +9,8 @@ import BusinessStructureStep from "@/components/form-steps/BusinessStructureStep
 import TaxStrategyStep from "@/components/form-steps/TaxStrategyStep";
 import OperationalDataStep from "@/components/form-steps/OperationalDataStep";
 import RiskProfileStep from "@/components/form-steps/RiskProfileStep";
+import AccountingDataStep from "@/components/form-steps/AccountingDataStep";
+import { toast } from "@/components/ui/sonner";
 import ResultsPage from "@/components/ResultsPage";
 import { FormData } from "@/types/form";
 
@@ -29,6 +31,13 @@ const TaxForm = ({ onBack }: TaxFormProps) => {
     expectedRevenue: "",
     hasEmployees: "",
     hasInternationalActivity: "",
+    annualIncome: "",
+    annualExpenses: "",
+    annualInvestment: "",
+    activityType: "",
+    currentLegalForm: "",
+    cnae: "",
+    expectedProfit: "",
     preferredTaxStructure: "",
     seekingInvestors: "",
     hasSpecialDeductions: "",
@@ -41,12 +50,13 @@ const TaxForm = ({ onBack }: TaxFormProps) => {
     riskLevel: ""
   });
 
-  const totalSteps = 5;
+  const totalSteps = 6;
   const progress = (currentStep / totalSteps) * 100;
 
   const stepTitles = [
     "Identidad Empresarial",
-    "Estructura y Actividad", 
+    "Estructura y Actividad",
+    "Datos Contables",
     "Estrategia Fiscal",
     "Datos Operativos",
     "Perfil de Riesgo"
@@ -60,7 +70,11 @@ const TaxForm = ({ onBack }: TaxFormProps) => {
     if (currentStep < totalSteps) {
       setCurrentStep(currentStep + 1);
     } else {
-      setCurrentStep(6); // Show results
+      if (!formData.expectedProfit || Number(formData.expectedProfit) <= 0) {
+        toast({ title: "Indica el beneficio esperado para comparar" });
+        return;
+      }
+      setCurrentStep(7); // Show results
     }
   };
 
@@ -77,19 +91,21 @@ const TaxForm = ({ onBack }: TaxFormProps) => {
       case 2:
         return <BusinessStructureStep formData={formData} updateFormData={updateFormData} />;
       case 3:
-        return <TaxStrategyStep formData={formData} updateFormData={updateFormData} />;
+        return <AccountingDataStep formData={formData} updateFormData={updateFormData} />;
       case 4:
-        return <OperationalDataStep formData={formData} updateFormData={updateFormData} />;
+        return <TaxStrategyStep formData={formData} updateFormData={updateFormData} />;
       case 5:
-        return <RiskProfileStep formData={formData} updateFormData={updateFormData} />;
+        return <OperationalDataStep formData={formData} updateFormData={updateFormData} />;
       case 6:
+        return <RiskProfileStep formData={formData} updateFormData={updateFormData} />;
+      case 7:
         return <ResultsPage formData={formData} onBack={onBack} />;
       default:
         return null;
     }
   };
 
-  if (currentStep === 6) {
+  if (currentStep === 7) {
     return renderStep();
   }
 

--- a/src/components/form-steps/AccountingDataStep.tsx
+++ b/src/components/form-steps/AccountingDataStep.tsx
@@ -1,0 +1,140 @@
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { FormData } from "@/types/form";
+
+interface AccountingDataStepProps {
+  formData: FormData;
+  updateFormData: (data: Partial<FormData>) => void;
+}
+
+const AccountingDataStep = ({ formData, updateFormData }: AccountingDataStepProps) => {
+  const activityTypes = [
+    "Agricultura",
+    "Industria",
+    "Comercio",
+    "Servicios",
+    "Profesional",
+    "Otro"
+  ];
+
+  const legalForms = [
+    "Autónomo",
+    "Sociedad Limitada",
+    "Sociedad Anónima",
+    "Comunidad de Bienes",
+    "Cooperativa",
+    "Otro"
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Label htmlFor="annualIncome" className="text-base font-medium">
+          Ingresos anuales (€)
+        </Label>
+        <Input
+          id="annualIncome"
+          type="number"
+          min="0"
+          value={formData.annualIncome}
+          onChange={(e) => updateFormData({ annualIncome: e.target.value })}
+          placeholder="Ej: 50000"
+          className="mt-2"
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="annualExpenses" className="text-base font-medium">
+          Gastos anuales (€)
+        </Label>
+        <Input
+          id="annualExpenses"
+          type="number"
+          min="0"
+          value={formData.annualExpenses}
+          onChange={(e) => updateFormData({ annualExpenses: e.target.value })}
+          placeholder="Ej: 20000"
+          className="mt-2"
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="annualInvestment" className="text-base font-medium">
+          Inversión prevista (€)
+        </Label>
+        <Input
+          id="annualInvestment"
+          type="number"
+          min="0"
+          value={formData.annualInvestment}
+          onChange={(e) => updateFormData({ annualInvestment: e.target.value })}
+          placeholder="Ej: 10000"
+          className="mt-2"
+        />
+      </div>
+
+      <div>
+        <Label className="text-base font-medium">Tipo de actividad</Label>
+        <Select value={formData.activityType} onValueChange={(value) => updateFormData({ activityType: value })}>
+          <SelectTrigger className="mt-2">
+            <SelectValue placeholder="Selecciona tipo de actividad" />
+          </SelectTrigger>
+          <SelectContent>
+            {activityTypes.map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <Label className="text-base font-medium">Forma jurídica actual</Label>
+        <Select value={formData.currentLegalForm} onValueChange={(value) => updateFormData({ currentLegalForm: value })}>
+          <SelectTrigger className="mt-2">
+            <SelectValue placeholder="Selecciona la forma jurídica" />
+          </SelectTrigger>
+          <SelectContent>
+            {legalForms.map((form) => (
+              <SelectItem key={form} value={form}>
+                {form}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <Label htmlFor="cnae" className="text-base font-medium">
+          Código CNAE
+        </Label>
+        <Input
+          id="cnae"
+          value={formData.cnae}
+          onChange={(e) => updateFormData({ cnae: e.target.value })}
+          placeholder="Ej: 6201"
+          className="mt-2"
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="expectedProfit" className="text-base font-medium">
+          Beneficio esperado (€)
+        </Label>
+        <Input
+          id="expectedProfit"
+          type="number"
+          min="0"
+          value={formData.expectedProfit}
+          onChange={(e) => updateFormData({ expectedProfit: e.target.value })}
+          placeholder="Ej: 15000"
+          className="mt-2"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AccountingDataStep;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -13,6 +13,15 @@ export interface FormData {
   expectedRevenue: string;
   hasEmployees: string;
   hasInternationalActivity: string;
+
+  // Accounting Data
+  annualIncome: string;
+  annualExpenses: string;
+  annualInvestment: string;
+  activityType: string;
+  currentLegalForm: string;
+  cnae: string;
+  expectedProfit: string;
   
   // Tax Strategy
   preferredTaxStructure: string;


### PR DESCRIPTION
## Summary
- extend form data with accounting fields
- add new AccountingDataStep step
- update TaxForm flow with validations and toast

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad29f86648332a981af29990ea9e0