### PR TITLE
Implement double entry tax comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## IRPF vs IS comparison
+
+The utilities folder provides `simulateDoubleEntry` to compare
+progressive IRPF with a flat corporate tax after deductions. This
+function returns the breakdown of both regimes so you can evaluate
+which option is more advantageous.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/fe3db85a-2546-4b50-8678-e68e945bf8ea) and click on Share -> Publish.

--- a/src/utils/doubleEntry.ts
+++ b/src/utils/doubleEntry.ts
@@ -1,0 +1,50 @@
+import { calculateIRPF, calculateCorporateTax } from './taxSimulator';
+
+export interface IRPFScenario {
+  grossIncome: number;
+  deductibleExpenses: number;
+  taxableIncome: number;
+  tax: number;
+}
+
+export interface ISScenario {
+  grossIncome: number;
+  deductibleExpenses: number;
+  taxableIncome: number;
+  tax: number;
+}
+
+export interface DoubleEntryResult {
+  irpf: IRPFScenario;
+  is: ISScenario;
+  difference: number;
+}
+
+export function simulateDoubleEntry(
+  grossIncome: number,
+  irpfExpenses: number,
+  isExpenses: number,
+  extraDeductions = 0
+): DoubleEntryResult {
+  const irpfTaxable = Math.max(0, grossIncome - irpfExpenses);
+  const irpfTax = calculateIRPF(irpfTaxable);
+
+  const isTaxable = Math.max(0, grossIncome - isExpenses - extraDeductions);
+  const isTax = calculateCorporateTax(isTaxable);
+
+  return {
+    irpf: {
+      grossIncome,
+      deductibleExpenses: irpfExpenses,
+      taxableIncome: irpfTaxable,
+      tax: irpfTax,
+    },
+    is: {
+      grossIncome,
+      deductibleExpenses: isExpenses + extraDeductions,
+      taxableIncome: isTaxable,
+      tax: isTax,
+    },
+    difference: irpfTax - isTax,
+  };
+}


### PR DESCRIPTION
## Summary
- add `simulateDoubleEntry` utility to compare IRPF (progressive) vs IS (flat)
- document new helper in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad294eb64833285edd7ff88536129