### PR TITLE
Add deduction validation with warnings

### DIFF
--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -5,6 +5,7 @@ import { Progress } from "@/components/ui/progress";
 import { ArrowLeft, Download, Calendar, TrendingDown, Shield, FileText, CheckCircle, AlertTriangle, Info, Calculator, Euro } from "lucide-react";
 import { FormData } from "@/types/form";
 import { evaluateFiscalRules, getRecommendedTaxStructure } from "@/utils/fiscalRules";
+import { validateDeductions } from "@/utils/deductions";
 import { compareScenarios, simulateAutonomoTaxes, simulateSLTaxes } from "@/utils/taxSimulator";
 
 interface ResultsPageProps {
@@ -210,24 +211,35 @@ const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
                     </p>
                   </div>
                   
-                  {applicableRules.map((rule, index) => (
-                    <div key={rule.id} className="bg-green-50 p-4 rounded-lg border border-green-200">
-                      <div className="flex items-start gap-2">
-                        <CheckCircle className="w-5 h-5 text-green-600 mt-0.5" />
-                        <div>
-                          <h4 className="font-medium text-green-800">{rule.name}</h4>
-                          <p className="text-sm text-green-700 mt-1">{rule.recommendation}</p>
-                          {rule.deductions && rule.deductions.length > 0 && (
-                            <ul className="text-xs text-green-600 mt-2 ml-4">
-                              {rule.deductions.map((deduction, i) => (
-                                <li key={i} className="list-disc">{deduction}</li>
-                              ))}
-                            </ul>
-                          )}
+                  {applicableRules.map((rule) => {
+                    const validated = rule.deductions
+                      ? validateDeductions(rule.deductions, recommendedStructure.type as 'autonomo' | 'sl')
+                      : [];
+
+                    return (
+                      <div key={rule.id} className="bg-green-50 p-4 rounded-lg border border-green-200">
+                        <div className="flex items-start gap-2">
+                          <CheckCircle className="w-5 h-5 text-green-600 mt-0.5" />
+                          <div>
+                            <h4 className="font-medium text-green-800">{rule.name}</h4>
+                            <p className="text-sm text-green-700 mt-1">{rule.recommendation}</p>
+                            {validated.length > 0 && (
+                              <ul className="text-xs text-green-600 mt-2 ml-4 space-y-1">
+                                {validated.map((ded, i) => (
+                                  <li key={i} className="list-disc">
+                                    {ded.name}
+                                    {ded.warnings.map((w, j) => (
+                                      <div key={j} className="text-yellow-700">{w}</div>
+                                    ))}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </CardContent>
             </Card>

--- a/src/utils/deductions.ts
+++ b/src/utils/deductions.ts
@@ -1,0 +1,63 @@
+export interface DeductionMeta {
+  applicableTo: 'autonomo' | 'sl' | 'both';
+  incompatibleWith?: string[];
+  warnings?: string[];
+}
+
+export const DEDUCTION_META: Record<string, DeductionMeta> = {
+  'Tipo reducido IS para startups (15% primeros dos períodos)': {
+    applicableTo: 'sl'
+  },
+  'Reserva de capitalización (10% sobre beneficios retenidos)': {
+    applicableTo: 'sl',
+    incompatibleWith: ['Tipo reducido IS para startups (15% primeros dos períodos)'],
+    warnings: ['Límite máximo por empresa']
+  },
+  'Deducción del 25% sobre gastos I+D+i': {
+    applicableTo: 'sl',
+    warnings: ['Esta deducción requiere informe motivado']
+  },
+  'Deducción adicional del 17% si supera la media de los dos años anteriores': {
+    applicableTo: 'sl'
+  },
+  'Deducción del 8% sobre inversiones en activos afectos a I+D+i': {
+    applicableTo: 'sl'
+  },
+  'Exención en IS por rentas obtenidas en el extranjero': {
+    applicableTo: 'sl'
+  },
+  'Deducción por doble imposición internacional': {
+    applicableTo: 'sl'
+  }
+};
+
+export interface ValidatedDeduction {
+  name: string;
+  warnings: string[];
+}
+
+export function validateDeductions(
+  deductions: string[],
+  taxStructure: 'autonomo' | 'sl'
+): ValidatedDeduction[] {
+  const results: ValidatedDeduction[] = [];
+  const applied = new Set<string>();
+
+  for (const name of deductions) {
+    const meta = DEDUCTION_META[name];
+    if (meta) {
+      if (meta.applicableTo === 'sl' && taxStructure === 'autonomo') {
+        continue;
+      }
+      if (meta.incompatibleWith && meta.incompatibleWith.some(i => applied.has(i))) {
+        continue;
+      }
+      applied.add(name);
+      results.push({ name, warnings: meta.warnings || [] });
+    } else {
+      results.push({ name, warnings: [] });
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- validate deductions to avoid incompatible or inapplicable ones
- show warnings for deductions that need special notes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad2cb19388332a17166fa7da81340