### PR TITLE
Implement fiscal alerts and calendar

### DIFF
--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -5,6 +5,7 @@ import { Progress } from "@/components/ui/progress";
 import { ArrowLeft, Download, Calendar, TrendingDown, Shield, FileText, CheckCircle, AlertTriangle, Info, Calculator, Euro } from "lucide-react";
 import { FormData } from "@/types/form";
 import { evaluateFiscalRules, getRecommendedTaxStructure } from "@/utils/fiscalRules";
+import { getDefaultFiscalAlerts, getUpcomingObligations } from "@/utils/fiscalAlerts";
 import { compareScenarios, simulateAutonomoTaxes, simulateSLTaxes } from "@/utils/taxSimulator";
 
 interface ResultsPageProps {
@@ -16,6 +17,8 @@ const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
   // Evaluación con el nuevo sistema de reglas
   const applicableRules = evaluateFiscalRules(formData);
   const recommendedStructure = getRecommendedTaxStructure(formData);
+  const fiscalAlerts = getDefaultFiscalAlerts(formData);
+  const obligations = getUpcomingObligations(new Date());
   
   // Simulación fiscal real
   const parseRevenue = (revenueRange: string): number => {
@@ -316,6 +319,28 @@ const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
               </CardContent>
             </Card>
 
+            {/* Fiscal Alerts */}
+            {fiscalAlerts.length > 0 && (
+              <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
+                <CardHeader>
+                  <CardTitle className="text-sm">Alertas Fiscales</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3 text-xs">
+                    {fiscalAlerts.map((alert) => (
+                      <div key={alert.id} className="flex items-start gap-2">
+                        <Info className="w-4 h-4 text-red-600 mt-0.5" />
+                        <div>
+                          <div className="font-medium">{alert.title}</div>
+                          <p>{alert.description}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
             {/* Compliance Alerts */}
             <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
               <CardHeader>
@@ -323,18 +348,12 @@ const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
               </CardHeader>
               <CardContent>
                 <div className="space-y-2 text-xs">
-                  <div className="flex justify-between">
-                    <span>IRPF/IS 2024</span>
-                    <Badge variant="outline" className="text-xs">Jun 2025</Badge>
-                  </div>
-                  <div className="flex justify-between">
-                    <span>IVA T1</span>
-                    <Badge variant="outline" className="text-xs">Ene 2025</Badge>
-                  </div>
-                  <div className="flex justify-between">
-                    <span>Modelo 303</span>
-                    <Badge variant="outline" className="text-xs">Ene 2025</Badge>
-                  </div>
+                  {obligations.map((ob) => (
+                    <div key={ob.model} className="flex justify-between">
+                      <span>{ob.model}</span>
+                      <Badge variant="outline" className="text-xs">{ob.dueDate}</Badge>
+                    </div>
+                  ))}
                 </div>
               </CardContent>
             </Card>

--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { ArrowLeft, Download, Calendar, TrendingDown, Shield, FileText, CheckCircle, AlertTriangle, Info, Calculator, Euro } from "lucide-react";
 import { FormData } from "@/types/form";
-import { evaluateFiscalRules, getRecommendedTaxStructure } from "@/utils/fiscalRules";
+import { evaluateFiscalRules, getRecommendedTaxStructure, parseRevenueValue } from "@/utils/fiscalRules";
 import { getDefaultFiscalAlerts, getUpcomingObligations } from "@/utils/fiscalAlerts";
 import { compareScenarios, simulateAutonomoTaxes, simulateSLTaxes } from "@/utils/taxSimulator";
 
@@ -21,16 +21,8 @@ const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
   const obligations = getUpcomingObligations(new Date());
   
   // Simulación fiscal real
-  const parseRevenue = (revenueRange: string): number => {
-    if (revenueRange.includes('Menos de 30.000€')) return 25000;
-    if (revenueRange.includes('30.000€ - 100.000€')) return 65000;
-    if (revenueRange.includes('100.000€ - 300.000€')) return 200000;
-    if (revenueRange.includes('300.000€ - 1M€')) return 650000;
-    if (revenueRange.includes('Más de 1M€')) return 1500000;
-    return 65000;
-  };
 
-  const estimatedRevenue = parseRevenue(formData.expectedRevenue);
+  const estimatedRevenue = parseRevenueValue(formData.expectedRevenue);
   const taxComparison = compareScenarios(estimatedRevenue, formData);
   
   // Cálculo específico para la estructura recomendada

--- a/src/utils/fiscalAlerts.ts
+++ b/src/utils/fiscalAlerts.ts
@@ -1,0 +1,116 @@
+export interface FiscalAlert {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface TaxObligation {
+  model: string;
+  dueDate: string;
+}
+
+import { FormData } from "@/types/form";
+import { parseRevenueValue } from "./fiscalRules";
+
+export function getDefaultFiscalAlerts(formData: FormData): FiscalAlert[] {
+  const alerts: FiscalAlert[] = [];
+  const revenue = parseRevenueValue(formData.expectedRevenue);
+
+  if (revenue > 600000) {
+    alerts.push({
+      id: "audit_alert",
+      title: "Auditor\u00eda obligatoria",
+      description:
+        "Al superar 600.000\u20ac de ingresos, la ley exige auditar las cuentas (art. 263 LSC).",
+    });
+  }
+
+  if (formData.hasPartners === "yes") {
+    alerts.push({
+      id: "partners_pact",
+      title: "Pactos de socios",
+      description:
+        "Es recomendable formalizar pactos de socios que regulen las entradas, salidas y reparto de beneficios.",
+    });
+  }
+
+  if (formData.hasInternationalActivity === "regular" || formData.hasInternationalActivity === "occasional") {
+    alerts.push({
+      id: "double_taxation",
+      title: "Doble imposici\u00f3n",
+      description:
+        "Revise convenios para evitar la doble imposici\u00f3n internacional y presente los modelos correspondientes.",
+    });
+  }
+
+  if (
+    formData.currentStatus === "operational" &&
+    formData.preferredTaxStructure &&
+    formData.preferredTaxStructure !== "unsure"
+  ) {
+    alerts.push({
+      id: "legal_change",
+      title: "Cambio de forma jur\u00eddica",
+      description:
+        "El cambio de forma jur\u00eddica implica gastos notariales, registros y diversos tr\u00e1mites administrativos.",
+    });
+  }
+
+  return alerts;
+}
+
+function nextDate(month: number, day: number, today: Date): Date {
+  const date = new Date(today.getFullYear(), month, day);
+  if (date <= today) {
+    date.setFullYear(today.getFullYear() + 1);
+  }
+  return date;
+}
+
+export function getUpcomingObligations(today = new Date()): TaxObligation[] {
+  const obligations: TaxObligation[] = [];
+
+  const modelo200 = nextDate(6, 25, today); // 25 de julio
+  obligations.push({
+    model: "Modelo 200",
+    dueDate: modelo200.toLocaleDateString("es-ES", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }),
+  });
+
+  const ivaDates = [
+    nextDate(0, 30, today),
+    nextDate(3, 20, today),
+    nextDate(6, 20, today),
+    nextDate(9, 20, today),
+  ].sort((a, b) => a.getTime() - b.getTime());
+  const modelo303Date = ivaDates.find((d) => d > today) || ivaDates[0];
+  obligations.push({
+    model: "Modelo 303",
+    dueDate: modelo303Date.toLocaleDateString("es-ES", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }),
+  });
+
+  const retDates = [
+    nextDate(0, 20, today),
+    nextDate(3, 20, today),
+    nextDate(6, 20, today),
+    nextDate(9, 20, today),
+  ].sort((a, b) => a.getTime() - b.getTime());
+  const modelo111Date = retDates.find((d) => d > today) || retDates[0];
+  obligations.push({
+    model: "Modelo 111",
+    dueDate: modelo111Date.toLocaleDateString("es-ES", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }),
+  });
+
+  return obligations;
+}

--- a/src/utils/fiscalRules.ts
+++ b/src/utils/fiscalRules.ts
@@ -150,7 +150,7 @@ export const FISCAL_RULES: FiscalRule[] = [
   }
 ];
 
-function parseRevenueValue(revenueRange: string): number {
+export function parseRevenueValue(revenueRange: string): number {
   if (!revenueRange) return 0;
   
   if (revenueRange.includes('Menos de 30.000€')) return 25000;

--- a/src/utils/fiscalRules.ts
+++ b/src/utils/fiscalRules.ts
@@ -139,7 +139,9 @@ export const FISCAL_RULES: FiscalRule[] = [
   {
     id: 'export_benefits',
     name: 'Beneficios por exportación',
-    condition: (data) => data.hasInternationalActivity === 'yes',
+    condition: (data) =>
+      data.hasInternationalActivity === 'regular' ||
+      data.hasInternationalActivity === 'occasional',
     recommendation: 'Las empresas exportadoras tienen incentivos fiscales.',
     deductions: [
       'Exención en IS por rentas obtenidas en el extranjero',


### PR DESCRIPTION
## Summary
- add `fiscalAlerts` utility with default alerts and tax calendar
- expose `parseRevenueValue`
- show fiscal alerts and upcoming obligations in results page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad2d2e0008332beff0324b35063c5