### PR TITLE
Add AEAT-based fiscal tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/utils/taxSimulator.ts
+++ b/src/utils/taxSimulator.ts
@@ -199,6 +199,43 @@ export function simulateSLTaxes(
   };
 }
 
+export function simulateCooperativeTaxes(
+  revenue: number,
+  formData: any,
+  customExpenses?: ExpenseBreakdown
+): TaxCalculation {
+  const deductibleExpenses = estimateDeductibleExpenses(
+    revenue,
+    formData.economicSector,
+    formData.hasEmployees === 'yes',
+    customExpenses
+  );
+
+  const memberSalary = Math.min(revenue * 0.3, 50000);
+  const totalExpenses = deductibleExpenses + memberSalary;
+
+  const taxableIncome = Math.max(0, revenue - totalExpenses);
+  const corporateTax = taxableIncome * 0.20;
+  const vatTax = calculateVAT(revenue) * 0.8;
+  const socialSecurity = calculateSocialSecurity('empleado', memberSalary);
+
+  const totalTaxes = corporateTax + vatTax + socialSecurity;
+  const netIncome = revenue - totalExpenses - totalTaxes;
+  const effectiveTaxRate = revenue > 0 ? (totalTaxes / revenue) * 100 : 0;
+
+  return {
+    grossRevenue: revenue,
+    deductibleExpenses: totalExpenses,
+    taxableIncome,
+    corporateTax,
+    vatTax,
+    socialSecurity,
+    totalTaxes,
+    netIncome,
+    effectiveTaxRate
+  };
+}
+
 export function compareScenarios(revenue: number, formData: any): {
   autonomo: TaxCalculation;
   sl: TaxCalculation;

--- a/tests/aeatCases.json
+++ b/tests/aeatCases.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "autonomo_estimacion_directa",
+    "revenue": 50000,
+    "expenses": {
+      "officeExpenses": 5000,
+      "equipmentDepreciation": 2000,
+      "professionalServices": 3000,
+      "training": 0,
+      "travel": 0,
+      "supplies": 0,
+      "other": 0
+    },
+    "expectedTaxableIncome": 40000
+  },
+  {
+    "name": "sl_sin_beneficios",
+    "revenue": 100000,
+    "expenses": {
+      "officeExpenses": 70000,
+      "equipmentDepreciation": 0,
+      "professionalServices": 0,
+      "training": 0,
+      "travel": 0,
+      "supplies": 0,
+      "other": 0
+    },
+    "expectedTaxableIncome": 0
+  },
+  {
+    "name": "cooperativa_trabajo",
+    "revenue": 200000,
+    "expenses": {
+      "officeExpenses": 50000,
+      "equipmentDepreciation": 5000,
+      "professionalServices": 10000,
+      "training": 0,
+      "travel": 0,
+      "supplies": 0,
+      "other": 0
+    },
+    "expectedCorporateRate": 0.20
+  }
+]

--- a/tests/taxSimulator.test.ts
+++ b/tests/taxSimulator.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, describe } from "bun:test";
+import { simulateAutonomoTaxes, simulateSLTaxes, simulateCooperativeTaxes } from "../src/utils/taxSimulator";
+import cases from "./aeatCases.json";
+
+const baseFormData = {
+  economicSector: "Tecnología e Informática",
+  hasEmployees: "no",
+  hasSpecialDeductions: "",
+  hasPartners: "no"
+};
+
+const autonomoCase = cases.find(c => c.name === "autonomo_estimacion_directa")!;
+const slCase = cases.find(c => c.name === "sl_sin_beneficios")!;
+const coopCase = cases.find(c => c.name === "cooperativa_trabajo")!;
+
+describe("Casos fiscales AEAT", () => {
+  test("Autónomo en estimación directa", () => {
+    const result = simulateAutonomoTaxes(
+      autonomoCase.revenue,
+      baseFormData,
+      autonomoCase.expenses
+    );
+    expect(result.taxableIncome).toBe(40000);
+    expect(Math.round(result.irpfTax)).toBe(10502);
+    expect(result.totalTaxes).toBeGreaterThan(30000);
+    expect(result.netIncome).toBeLessThan(10000);
+    expect(result.totalTaxes).toBeGreaterThanOrEqual(0);
+  });
+
+  test("SL sin beneficios", () => {
+    const form = { ...baseFormData, hasEmployees: "yes" };
+    const result = simulateSLTaxes(
+      slCase.revenue,
+      form,
+      slCase.expenses
+    );
+    expect(result.taxableIncome).toBe(0);
+    expect(result.corporateTax).toBe(0);
+    expect(result.totalTaxes).toBeGreaterThan(0);
+    expect(result.totalTaxes).toBeGreaterThanOrEqual(0);
+  });
+
+  test("Cooperativa de trabajo", () => {
+    const form = { ...baseFormData, hasEmployees: "yes" };
+    const result = simulateCooperativeTaxes(
+      coopCase.revenue,
+      form,
+      coopCase.expenses
+    );
+    expect(result.corporateTax).toBeCloseTo(0.2 * result.taxableIncome, 2);
+    expect(result.totalTaxes).toBeGreaterThan(0);
+    expect(result.effectiveTaxRate).toBeLessThan(100);
+    expect(result.totalTaxes).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- create AEAT sample cases dataset
- add bun test script
- implement `simulateCooperativeTaxes`
- provide fiscal tests for autónomo, SL and cooperatives

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684ad2ee5d1083329407b7aa384d6cd4