### PR TITLE
Add quick assessment flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import CasosExito from "./pages/CasosExito";
+import Simplified from "./pages/Simplified";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +20,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/casos-exito" element={<CasosExito />} />
+          <Route path="/rapido" element={<Simplified />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/LandingSection.tsx
+++ b/src/components/LandingSection.tsx
@@ -155,15 +155,26 @@ const LandingSection = ({ onStartForm }: LandingSectionProps) => {
             <p className="text-xl mb-8 opacity-90">
               Únete a más de 500 empresas que ya han reducido sus impuestos legalmente
             </p>
-            <Button 
-              onClick={onStartForm}
-              size="lg" 
-              variant="secondary"
-              className="bg-white text-blue-600 hover:bg-gray-100 text-lg px-8 py-6 shadow-lg hover:shadow-xl transition-all duration-300"
-            >
-              <FileText className="mr-2" />
-              Empezar ahora - Es gratis
-            </Button>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Button
+                onClick={onStartForm}
+                size="lg"
+                variant="secondary"
+                className="bg-white text-blue-600 hover:bg-gray-100 text-lg px-8 py-6 shadow-lg hover:shadow-xl transition-all duration-300"
+              >
+                <FileText className="mr-2" />
+                Diagnóstico completo
+              </Button>
+              <Link to="/rapido">
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="text-white border-white/70 hover:bg-white hover:text-blue-600 text-lg px-8 py-6"
+                >
+                  Versión rápida
+                </Button>
+              </Link>
+            </div>
           </div>
         </div>
       </section>

--- a/src/components/simplified/QuickResults.tsx
+++ b/src/components/simplified/QuickResults.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getRecommendedTaxStructure, parseRevenueValue } from "@/utils/fiscalRules";
+import { compareScenarios } from "@/utils/taxSimulator";
+
+interface QuickResultsProps {
+  expectedRevenue: string;
+  hasPartners: string;
+  onReset: () => void;
+}
+
+const QuickResults = ({ expectedRevenue, hasPartners, onReset }: QuickResultsProps) => {
+  const revenueValue = parseRevenueValue(expectedRevenue);
+  const comparison = compareScenarios(revenueValue, { expectedRevenue, hasPartners });
+  const recommended = getRecommendedTaxStructure({ expectedRevenue, hasPartners });
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat("es-ES", { style: "currency", currency: "EUR" }).format(amount);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50 py-8">
+      <div className="container mx-auto px-4 max-w-lg">
+        <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle className="text-center text-xl">Resultado Simplificado</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="text-center">
+              <div className="text-sm text-muted-foreground mb-1">Forma jurídica sugerida</div>
+              <div className="text-2xl font-bold text-blue-600">{recommended.name}</div>
+            </div>
+            <div className="text-center">
+              <div className="text-sm text-muted-foreground mb-1">Ahorro estimado</div>
+              <div className="text-2xl font-bold text-green-600">
+                {formatCurrency(Math.abs(comparison.savings))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Button onClick={onReset} className="w-full bg-gradient-to-r from-blue-600 to-green-600">
+                Volver
+              </Button>
+              <a href="tel:900123456" className="block text-center text-sm">📞 900 123 456</a>
+              <a href="mailto:info@fiscaloptima.es" className="block text-center text-sm">
+                ✉️ info@fiscaloptima.es
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default QuickResults;

--- a/src/components/simplified/SimplifiedForm.tsx
+++ b/src/components/simplified/SimplifiedForm.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import QuickResults from "./QuickResults";
+
+const revenueRanges = [
+  "Menos de 30.000€",
+  "30.000€ - 100.000€",
+  "100.000€ - 300.000€",
+  "300.000€ - 1M€",
+  "Más de 1M€"
+];
+
+const SimplifiedForm = () => {
+  const [step, setStep] = useState(1);
+  const [expectedRevenue, setExpectedRevenue] = useState("");
+  const [hasPartners, setHasPartners] = useState("");
+
+  if (step === 3) {
+    return (
+      <QuickResults
+        expectedRevenue={expectedRevenue}
+        hasPartners={hasPartners}
+        onReset={() => {
+          setStep(1);
+          setExpectedRevenue("");
+          setHasPartners("");
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50 py-8">
+      <div className="container mx-auto px-4 max-w-lg">
+        <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle className="text-center text-xl">Diagnóstico Rápido</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {step === 1 && (
+              <div>
+                <label className="font-medium">Facturación prevista</label>
+                <Select value={expectedRevenue} onValueChange={setExpectedRevenue}>
+                  <SelectTrigger className="mt-2">
+                    <SelectValue placeholder="Selecciona un rango" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {revenueRanges.map((range) => (
+                      <SelectItem key={range} value={range}>
+                        {range}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {step === 2 && (
+              <div>
+                <label className="font-medium">¿Tienes socios?</label>
+                <RadioGroup value={hasPartners} onValueChange={setHasPartners} className="mt-2">
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="no" id="partners-no" />
+                    <label htmlFor="partners-no">No</label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="yes" id="partners-yes" />
+                    <label htmlFor="partners-yes">Sí</label>
+                  </div>
+                </RadioGroup>
+              </div>
+            )}
+            <div className="flex justify-between pt-4 border-t">
+              {step > 1 && (
+                <Button variant="outline" onClick={() => setStep(step - 1)}>
+                  Anterior
+                </Button>
+              )}
+              <Button
+                onClick={() => setStep(step + 1)}
+                disabled={step === 1 ? !expectedRevenue : !hasPartners}
+                className="bg-gradient-to-r from-blue-600 to-green-600"
+              >
+                {step === 2 ? "Ver resultado" : "Siguiente"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default SimplifiedForm;

--- a/src/pages/Simplified.tsx
+++ b/src/pages/Simplified.tsx
@@ -1,0 +1,5 @@
+import SimplifiedForm from "@/components/simplified/SimplifiedForm";
+
+const Simplified = () => <SimplifiedForm />;
+
+export default Simplified;

--- a/src/utils/fiscalRules.ts
+++ b/src/utils/fiscalRules.ts
@@ -150,7 +150,7 @@ export const FISCAL_RULES: FiscalRule[] = [
   }
 ];
 
-function parseRevenueValue(revenueRange: string): number {
+export function parseRevenueValue(revenueRange: string): number {
   if (!revenueRange) return 0;
   
   if (revenueRange.includes('Menos de 30.000€')) return 25000;


### PR DESCRIPTION
## Summary
- add simplified quick form components
- allow quick results with estimated savings and suggested entity
- link from landing to new `/rapido` route
- export revenue parsing utility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad2e47b3c83329a5771433d0b2205