### PR TITLE
Implement legal rule versioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import CasosExito from "./pages/CasosExito";
+import LegalChanges from "./pages/LegalChanges";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +20,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/casos-exito" element={<CasosExito />} />
+          <Route path="/cambios-legales" element={<LegalChanges />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/LandingSection.tsx
+++ b/src/components/LandingSection.tsx
@@ -56,9 +56,9 @@ const LandingSection = ({ onStartForm }: LandingSectionProps) => {
           </p>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-            <Button 
+            <Button
               onClick={onStartForm}
-              size="lg" 
+              size="lg"
               className="bg-gradient-to-r from-blue-600 to-green-600 hover:from-blue-700 hover:to-green-700 text-lg px-8 py-6 shadow-lg hover:shadow-xl transition-all duration-300"
             >
               <FileText className="mr-2" />
@@ -67,6 +67,11 @@ const LandingSection = ({ onStartForm }: LandingSectionProps) => {
             <Link to="/casos-exito">
               <Button variant="outline" size="lg" className="text-lg px-8 py-6">
                 Ver casos de éxito
+              </Button>
+            </Link>
+            <Link to="/cambios-legales">
+              <Button variant="outline" size="lg" className="text-lg px-8 py-6">
+                Cambios legales
               </Button>
             </Link>
           </div>

--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -14,8 +14,9 @@ interface ResultsPageProps {
 
 const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
   // Evaluación con el nuevo sistema de reglas
-  const applicableRules = evaluateFiscalRules(formData);
-  const recommendedStructure = getRecommendedTaxStructure(formData);
+  const fiscalYear = 2024;
+  const applicableRules = evaluateFiscalRules(formData, fiscalYear);
+  const recommendedStructure = getRecommendedTaxStructure(formData, fiscalYear);
   
   // Simulación fiscal real
   const parseRevenue = (revenueRange: string): number => {

--- a/src/pages/LegalChanges.tsx
+++ b/src/pages/LegalChanges.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { getRuleChangesByFiscalYear, FiscalRule } from "@/utils/fiscalRules";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { Link } from "react-router-dom";
+
+const LegalChanges = () => {
+  const years = [2024, 2023];
+  const [year, setYear] = useState<number>(years[0]);
+  const changes: FiscalRule[] = getRuleChangesByFiscalYear(year);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50 py-8">
+      <div className="container mx-auto px-4 max-w-4xl">
+        <div className="flex items-center gap-4 mb-8">
+          <Link to="/">
+            <Button variant="ghost" className="p-2">
+              <ArrowLeft className="w-5 h-5" />
+            </Button>
+          </Link>
+          <h1 className="text-2xl font-bold flex-1">Cambios legales por año</h1>
+        </div>
+        <div className="mb-4">
+          <select
+            value={year}
+            onChange={e => setYear(parseInt(e.target.value))}
+            className="border p-2 rounded"
+          >
+            {years.map(y => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </div>
+        <Card className="border-0 shadow-xl bg-white/80 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Actualizaciones {year}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {changes.length === 0 && (
+              <p className="text-muted-foreground">Sin cambios registrados</p>
+            )}
+            {changes.map(rule => (
+              <div key={rule.id} className="border-b pb-2 last:border-b-0">
+                <div className="font-medium">{rule.name}</div>
+                <div className="text-sm text-muted-foreground">
+                  BOE: {rule.sourceBOE} - {rule.startDate}
+                  {rule.endDate ? ` → ${rule.endDate}` : ""}
+                </div>
+                <div className="text-sm">{rule.recommendation}</div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default LegalChanges;


### PR DESCRIPTION
## Summary
- extend fiscal rules with legal versioning info
- add utilities to filter rule sets by fiscal year
- update evaluation logic to support fiscal year parameter
- expose legal changes via new LegalChanges page
- add navigation link and routing for legal changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684ad2f50b70833288636582776570ab