### PR TITLE
Add dynamic rule engine

### DIFF
--- a/public/rules.json
+++ b/public/rules.json
@@ -1,0 +1,12 @@
+[
+  {
+    "condiciones": {
+      "sector": "Tecnología",
+      "facturacionMin": 50000,
+      "socios": true
+    },
+    "recomendacion": "Sociedad Limitada",
+    "tipoImpositivo": 25,
+    "deducciones": ["I+D+i"]
+  }
+]

--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -5,6 +5,8 @@ import { Progress } from "@/components/ui/progress";
 import { ArrowLeft, Download, Calendar, TrendingDown, Shield, FileText, CheckCircle, AlertTriangle, Info, Calculator, Euro } from "lucide-react";
 import { FormData } from "@/types/form";
 import { evaluateFiscalRules, getRecommendedTaxStructure } from "@/utils/fiscalRules";
+import { getExternalRecommendation, ExternalRule } from "@/utils/dynamicRules";
+import { useState, useEffect } from "react";
 import { compareScenarios, simulateAutonomoTaxes, simulateSLTaxes } from "@/utils/taxSimulator";
 
 interface ResultsPageProps {
@@ -16,6 +18,12 @@ const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
   // Evaluación con el nuevo sistema de reglas
   const applicableRules = evaluateFiscalRules(formData);
   const recommendedStructure = getRecommendedTaxStructure(formData);
+
+  const [externalRecommendation, setExternalRecommendation] = useState<ExternalRule | null>(null);
+
+  useEffect(() => {
+    getExternalRecommendation(formData).then(setExternalRecommendation);
+  }, [formData]);
   
   // Simulación fiscal real
   const parseRevenue = (revenueRange: string): number => {
@@ -65,6 +73,25 @@ const ResultsPage = ({ formData, onBack }: ResultsPageProps) => {
             </Button>
           </div>
         </div>
+
+        {externalRecommendation && (
+          <Card className="mb-8 border-0 shadow-xl bg-white/80 backdrop-blur-sm">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Info className="w-5 h-5 text-blue-600" />
+                Regla externa aplicada
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-2">{externalRecommendation.recomendacion}</p>
+              {externalRecommendation.deducciones && (
+                <div className="text-sm text-muted-foreground">
+                  Deducciones: {externalRecommendation.deducciones.join(', ')}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         <div className="grid lg:grid-cols-3 gap-8">
           {/* Main Results */}

--- a/src/utils/dynamicRules.ts
+++ b/src/utils/dynamicRules.ts
@@ -1,0 +1,43 @@
+import { FormData } from "@/types/form";
+import { parseRevenueValue } from "@/utils/fiscalRules";
+
+export interface ExternalRule {
+  condiciones: {
+    sector?: string;
+    facturacionMin?: number;
+    facturacionMax?: number;
+    socios?: boolean;
+  };
+  recomendacion: string;
+  tipoImpositivo?: number;
+  deducciones?: string[];
+}
+
+let cachedRules: ExternalRule[] | null = null;
+
+async function loadExternalRules(): Promise<ExternalRule[]> {
+  if (cachedRules) return cachedRules;
+  const response = await fetch("/rules.json");
+  const data = await response.json();
+  cachedRules = Array.isArray(data) ? data : [data];
+  return cachedRules;
+}
+
+export async function evaluateExternalRules(formData: FormData): Promise<ExternalRule[]> {
+  const rules = await loadExternalRules();
+  const revenue = parseRevenueValue(formData.expectedRevenue);
+
+  return rules.filter(rule => {
+    const cond = rule.condiciones || {};
+    if (cond.sector && cond.sector !== formData.economicSector) return false;
+    if (cond.facturacionMin && revenue < cond.facturacionMin) return false;
+    if (cond.facturacionMax && revenue > cond.facturacionMax) return false;
+    if (typeof cond.socios === "boolean" && (formData.hasPartners === "yes") !== cond.socios) return false;
+    return true;
+  });
+}
+
+export async function getExternalRecommendation(formData: FormData): Promise<ExternalRule | null> {
+  const applicable = await evaluateExternalRules(formData);
+  return applicable.length > 0 ? applicable[0] : null;
+}

--- a/src/utils/fiscalRules.ts
+++ b/src/utils/fiscalRules.ts
@@ -150,7 +150,7 @@ export const FISCAL_RULES: FiscalRule[] = [
   }
 ];
 
-function parseRevenueValue(revenueRange: string): number {
+export function parseRevenueValue(revenueRange: string): number {
   if (!revenueRange) return 0;
   
   if (revenueRange.includes('Menos de 30.000€')) return 25000;


### PR DESCRIPTION
## Summary
- export revenue parser
- load external rules from `public/rules.json`
- evaluate dynamic rules with a helper
- surface external rule recommendation on the results page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad2bc3a0c83329ad2465cff94fa9f